### PR TITLE
Revert "Use follows from instead of child of semantics for consumer"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 Changelog
 =========
 
-## 0.3.0 09/06/2019
-  * Use follows from instead of child of semantics for consumer
-
 ## 0.2.0 08/16/2019
   * Catch load errors when kafka is not present
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kafka-opentracing (0.3.0)
+    kafka-opentracing (0.2.0)
       opentracing (~> 0.5.0)
 
 GEM
@@ -38,4 +38,4 @@ DEPENDENCIES
   ruby-kafka (>= 0.7.0)
 
 BUNDLED WITH
-   2.0.2
+   2.0.1

--- a/lib/kafka/tracer.rb
+++ b/lib/kafka/tracer.rb
@@ -192,7 +192,7 @@ module Kafka
                 'message_bus.pre_fetched_in_batch' => true
               }
 
-              tracer.start_active_span('kafka.consumer', follows_from: context, tags: tags) do |scope|
+              tracer.start_active_span('kafka.consumer', child_of: context, tags: tags) do |scope|
                 begin
                   block.call(message)
                 rescue StandardError
@@ -232,7 +232,7 @@ module Kafka
                 'message_bus.pre_fetched_in_batch' => true
               }
 
-              tracer.start_active_span('kafka.consumer', follows_from: context, tags: tags) do |scope|
+              tracer.start_active_span('kafka.consumer', child_of: context, tags: tags) do |scope|
                 begin
                   yield message
                 rescue StandardError

--- a/lib/kafka/tracer/version.rb
+++ b/lib/kafka/tracer/version.rb
@@ -2,6 +2,6 @@
 
 module Kafka
   module Tracer
-    VERSION = '0.3.0'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/kafka/tracer_spec.rb
+++ b/spec/kafka/tracer_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Kafka::Tracer do
 
       expect(tracer).to have_received(:start_active_span).with(
         'kafka.consumer',
-        follows_from: context,
+        child_of: context,
         tags: {
           'component' => 'ruby-kafka',
           'span.kind' => 'consumer',
@@ -273,7 +273,7 @@ RSpec.describe Kafka::Tracer do
 
       expect(tracer).to have_received(:start_active_span).with(
         'kafka.consumer',
-        follows_from: context,
+        child_of: context,
         tags: {
           'component' => 'ruby-kafka',
           'span.kind' => 'consumer',


### PR DESCRIPTION
Reverts benedictfischer09/ruby-kafka-instrumentation#3